### PR TITLE
Fix wrong bracket position in MRT calculation

### DIFF
--- a/thermofeel/thermofeel.py
+++ b/thermofeel/thermofeel.py
@@ -326,7 +326,7 @@ def calculate_mean_radiant_temperature(ssrd, ssr, fdir, strd, strr, cossza):
     # calculate fp projected factor area
 
     gamma = np.arcsin(cossza) * 180 / np.pi
-    fp = 0.308 * np.cos(to_radians * gamma * 0.998 - (gamma * gamma / 50000))
+    fp = 0.308 * np.cos(to_radians * gamma * (0.998 - gamma * gamma / 50000))
 
     # filter statement for solar zenith angle
     csza_filter1 = np.where((cossza > 0.01))

--- a/thermofeel/thermofeel.py
+++ b/thermofeel/thermofeel.py
@@ -329,9 +329,8 @@ def calculate_mean_radiant_temperature(ssrd, ssr, fdir, strd, strr, cossza):
     fp = 0.308 * np.cos(to_radians * gamma * (0.998 - gamma * gamma / 50000))
 
     # filter statement for solar zenith angle
-    csza_filter1 = np.where((cossza > 0.01))
-    # print(csza_filter1)
-    fdir[csza_filter1] = fdir[csza_filter1] / cossza[csza_filter1]
+    csza = np.where(cossza > 0.01, cossza, 1)
+    fdir = fdir / csza
 
     # calculate mean radiant temperature
     mrt = np.power(


### PR DESCRIPTION
* The bracket position in the code for calculating $f_p$ is wrong when compared to eq. (15) of the reference.
* The `csza_filter1` part is fixed so that multi-dimensional array can also be used as input. Current code is only usable for 1d-array.