### PR TITLE
Add excess heat and cold factor formulas in new submodule

### DIFF
--- a/docs/source/guide/excess_heat.rst
+++ b/docs/source/guide/excess_heat.rst
@@ -27,22 +27,24 @@ References
 How To Use
 ----------
 
-The indices are computed in a pipeline of steps, as described in the subsections
-below. Each step builds on the output of the previous one.
-
 .. note::
 
-    The functions defined here only implement the basic formulas of the indices,
+    The functions defined here only implement the basic formulas of the indices
     but not the required aggregations of the input data. The intermediate
     aggregated quantities required by the pipeline, including running means
     of daily mean temperature and climatological percentile thresholds, can, for
     example, be computed with `earthkit.transforms <https://earthkit-transforms.readthedocs.io>`_.
 
-**Daily Mean Temperature**
 
-The first step is to compute the daily mean temperature from the 2-metre daily
-minimum and maximum temperatures. Both inputs must be in the same unit (K or °C);
-the output is in the same unit.
+Daily Mean Temperature
+######################
+
+The excess heat and cold factor computations are based on 2-metre daily mean
+temperature.
+
+Nairn and Fawcett (2014) approximate the daily mean temperature
+with the average of the daily minimum and maximum temperatures which are more
+readily available as inputs from long-running historical records.
 
 .. code-block:: python
 
@@ -50,13 +52,16 @@ the output is in the same unit.
 
     dmt = daily_mean_temperature(t2_min, t2_max)
 
-**Significance Index**
+Both inputs must be in the same unit (K or °C); the output is in the same unit.
+
+
+Significance Index
+##################
 
 The significance index measures how far the 3-day running mean of daily mean
 temperature exceeds a climatological threshold. For heat events the threshold is
 typically the 95th percentile of daily mean temperature over a reference period;
-for cold events the 5th percentile is used instead. The output unit matches the
-input unit (K or °C).
+for cold events the 5th percentile is used instead.
 
 .. code-block:: python
 
@@ -68,11 +73,23 @@ input unit (K or °C).
     # cold events: threshold = 5th-percentile climatology of dmt
     ehi_sig_cold = significance_index(dmt_3day_mean, threshold_5th)
 
-**Acclimatisation Index**
+The output unit matches the input unit.
+
+.. note::
+
+    The use of a static climatological threshold in the significance index
+    means that indicated hot and cold extremes will almost exclusively occur
+    in the summer or winter seasons, respectively. A time-varying climatological
+    threshold allows for the detection of warm and cold *spells* (relative
+    anomalies) instead.
+
+
+Acclimatisation Index
+#####################
 
 The acclimatisation index measures how far the 3-day running mean of daily mean
-temperature exceeds the 30-day running mean of daily mean temperature in the
-preceding period. The output unit matches the input unit (K or °C).
+temperature (days i, i+1, i+2) exceeds the 30-day running mean of daily mean
+temperature in the preceding period (days i-30, ..., i-1).
 
 .. code-block:: python
 
@@ -80,12 +97,15 @@ preceding period. The output unit matches the input unit (K or °C).
 
     ehi_accl = acclimatisation_index(dmt_3day_mean, dmt_30day_mean)
 
-**Excess Heat Factor**
+The output unit matches the input unit.
 
-The excess heat factor is the product of the significance index and the
-acclimatisation index (clamped from below at 1). It is returned in K² (or °C²
-if the inputs are in °C). Optionally, set ``clip=True`` to restrict the result
-to non-negative values, retaining only heat events.
+
+Excess Heat Factor
+##################
+
+The excess heat factor combines the significance index and the acclimatisation
+index. Optionally, set ``clip=True`` to restrict the EXHF to non-negative
+values.
 
 .. code-block:: python
 
@@ -94,12 +114,15 @@ to non-negative values, retaining only heat events.
     exhf = excess_heat_factor(ehi_sig_heat, ehi_accl)
     exhf_clipped = excess_heat_factor(ehi_sig_heat, ehi_accl, clip=True)
 
-**Heatwave Severity**
+The output unit is the input unit squared, e.g., K².
 
-The heatwave severity index normalises the excess heat factor by a threshold —
-typically the 85th percentile of all *positive* EXHF values over a reference
-period — to produce a dimensionless measure of event severity relative to a
-historical baseline.
+Heatwave Severity
+#################
+
+The heatwave severity index normalises the excess heat factor by a threshold
+to produce a dimensionless measure of event severity relative to a historical
+baseline. The 85th percentile of all *positive* EXHF values over a reference
+period is typically used as the threshold value.
 
 .. code-block:: python
 
@@ -107,7 +130,11 @@ historical baseline.
 
     hsev = heatwave_severity(exhf, threshold_exhf_85th)
 
-**Excess Cold Factor**
+The severity index is nondimensional.
+
+
+Excess Cold Factor
+##################
 
 The excess cold factor uses the same formulation as the excess heat factor but
 is symmetric about zero to capture cold extremes. Use the significance index
@@ -120,3 +147,5 @@ restrict the result to non-negative values, retaining only cold events.
 
     excf = excess_cold_factor(ehi_sig_cold, ehi_accl)
     excf_clipped = excess_cold_factor(ehi_sig_cold, ehi_accl, clip=True)
+
+The output unit is the input unit squared, e.g., K².

--- a/docs/source/guide/excess_heat.rst
+++ b/docs/source/guide/excess_heat.rst
@@ -1,0 +1,122 @@
+Excess Heat and Cold Factors
+============================
+
+The **Excess Heat Factor** (EXHF) and **Excess Cold Factor** (EXCF) are thermal
+indices that quantify the hazard of extreme heat and cold events.
+
+Each index combines two components: a *significance index* that measures how
+much the current temperature exceeds a climatological threshold, and an
+*acclimatisation index* that measures how much the current temperature departs
+from the recent past. EXHF or EXCF indicate events that are both unusually hot
+or cold relative to climatology *and* to which the population has had little
+time to acclimatise, and are therefore associated with elevated health risk.
+
+The indices and their reference definitions typically use a day defined from
+9 am to 9 am local time, so that the daily maximum typically precedes the daily
+minimum. This accounts for the greater physiological significance of a hot night
+following a hot day compared to the other way around.
+
+References
+----------
+
+* Nairn, J., & Fawcett, R. (2014). The Excess Heat Factor: A Metric for Heatwave Intensity and Its Use in Classifying Heatwave Severity. *Int J Environ Res Public Health*, 12(1), 227–253. https://doi.org/10.3390/ijerph120100227
+* Nairn, J. (2013). Defining heatwaves: heatwave defined as a heat-impact event servicing all community and business sectors in Australia. CAWCR Technical Report No. 060. https://www.cawcr.gov.au/technical-reports/CTR_060.pdf
+* Nairn, J. (2018). Heatwave Severity. *Int J Environ Res Public Health*, 15(11), 2494. https://doi.org/10.3390/ijerph15112494
+
+
+How To Use
+----------
+
+The indices are computed in a pipeline of steps, as described in the subsections
+below. Each step builds on the output of the previous one.
+
+.. note::
+
+    The functions defined here only implement the basic formulas of the indices,
+    but not the required aggregations of the input data. The intermediate
+    aggregated quantities required by the pipeline, including running means
+    of daily mean temperature and climatological percentile thresholds, can, for
+    example, be computed with `earthkit.transforms <https://earthkit-transforms.readthedocs.io>`_.
+
+**Daily Mean Temperature**
+
+The first step is to compute the daily mean temperature from the 2-metre daily
+minimum and maximum temperatures. Both inputs must be in the same unit (K or °C);
+the output is in the same unit.
+
+.. code-block:: python
+
+    from thermofeel.excess_heat import daily_mean_temperature
+
+    dmt = daily_mean_temperature(t2_min, t2_max)
+
+**Significance Index**
+
+The significance index measures how far the 3-day running mean of daily mean
+temperature exceeds a climatological threshold. For heat events the threshold is
+typically the 95th percentile of daily mean temperature over a reference period;
+for cold events the 5th percentile is used instead. The output unit matches the
+input unit (K or °C).
+
+.. code-block:: python
+
+    from thermofeel.excess_heat import significance_index
+
+    # heat events: threshold = 95th-percentile climatology of dmt
+    ehi_sig_heat = significance_index(dmt_3day_mean, threshold_95th)
+
+    # cold events: threshold = 5th-percentile climatology of dmt
+    ehi_sig_cold = significance_index(dmt_3day_mean, threshold_5th)
+
+**Acclimatisation Index**
+
+The acclimatisation index measures how far the 3-day running mean of daily mean
+temperature exceeds the 30-day running mean of daily mean temperature in the
+preceding period. The output unit matches the input unit (K or °C).
+
+.. code-block:: python
+
+    from thermofeel.excess_heat import acclimatisation_index
+
+    ehi_accl = acclimatisation_index(dmt_3day_mean, dmt_30day_mean)
+
+**Excess Heat Factor**
+
+The excess heat factor is the product of the significance index and the
+acclimatisation index (clamped from below at 1). It is returned in K² (or °C²
+if the inputs are in °C). Optionally, set ``clip=True`` to restrict the result
+to non-negative values, retaining only heat events.
+
+.. code-block:: python
+
+    from thermofeel.excess_heat import excess_heat_factor
+
+    exhf = excess_heat_factor(ehi_sig_heat, ehi_accl)
+    exhf_clipped = excess_heat_factor(ehi_sig_heat, ehi_accl, clip=True)
+
+**Heatwave Severity**
+
+The heatwave severity index normalises the excess heat factor by a threshold —
+typically the 85th percentile of all *positive* EXHF values over a reference
+period — to produce a dimensionless measure of event severity relative to a
+historical baseline.
+
+.. code-block:: python
+
+    from thermofeel.excess_heat import heatwave_severity
+
+    hsev = heatwave_severity(exhf, threshold_exhf_85th)
+
+**Excess Cold Factor**
+
+The excess cold factor uses the same formulation as the excess heat factor but
+is symmetric about zero to capture cold extremes. Use the significance index
+computed against the 5th-percentile threshold. Optionally set ``clip=True`` to
+restrict the result to non-negative values, retaining only cold events.
+
+.. code-block:: python
+
+    from thermofeel.excess_heat import excess_cold_factor
+
+    excf = excess_cold_factor(ehi_sig_cold, ehi_accl)
+    excf_clipped = excess_cold_factor(ehi_sig_cold, ehi_accl, clip=True)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,7 @@ Indices and tables
    guide/windchill
    guide/relativehumidity
    guide/mrt
+   guide/excess_heat
 
 License
 -------

--- a/tests/test_excess_heat.py
+++ b/tests/test_excess_heat.py
@@ -13,24 +13,24 @@ import thermofeel as tmf
 
 
 def test_daily_mean_temperature():
-    t2_min = np.asarray([1., 2., 3., 4., 5.])
-    t2_max = np.asarray([5., 2., 5., 4., 7.])
+    t2_min = np.asarray([1.0, 2.0, 3.0, 4.0, 5.0])
+    t2_max = np.asarray([5.0, 2.0, 5.0, 4.0, 7.0])
     dmt = tmf.excess_heat.daily_mean_temperature(t2_min, t2_max)
-    np.testing.assert_allclose(dmt, [3., 2., 4., 4., 6.])
+    np.testing.assert_allclose(dmt, [3.0, 2.0, 4.0, 4.0, 6.0])
 
 
 def test_significance_index():
-    dmt = np.asarray([3., 4., 5., 6., 7., 8., 9.])
-    threshold = 5.
+    dmt = np.asarray([3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+    threshold = 5.0
     ehi_sig = tmf.excess_heat.significance_index(dmt, threshold)
-    np.testing.assert_allclose(ehi_sig, [-2., -1., 0., 1., 2., 3., 4.])
+    np.testing.assert_allclose(ehi_sig, [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0])
 
 
 def test_acclimatisation_index():
-    dmt = np.asarray([3., 4., 5., 6., 7., 8., 9.])
-    threshold = np.asarray([2., 2., 3., 3., 4., 4., 3.])
+    dmt = np.asarray([3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+    threshold = np.asarray([2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 3.0])
     ehi_accl = tmf.excess_heat.acclimatisation_index(dmt, threshold)
-    np.testing.assert_allclose(ehi_accl, [1., 2., 2., 3., 3., 4., 6.])
+    np.testing.assert_allclose(ehi_accl, [1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 6.0])
 
 
 class TestExcessHeatAndColdFactors:
@@ -45,19 +45,25 @@ class TestExcessHeatAndColdFactors:
 
     def test_excess_heat_factor_with_clip_false(self, ehi_sig, ehi_accl):
         exhf = tmf.excess_heat.excess_heat_factor(ehi_sig, ehi_accl, clip=False)
-        np.testing.assert_allclose(exhf, [15.0, 5.0, 5.0, 0.0, 0.0, 0.0, -6.0, -2.0, -2.0])
+        np.testing.assert_allclose(
+            exhf, [15.0, 5.0, 5.0, 0.0, 0.0, 0.0, -6.0, -2.0, -2.0]
+        )
 
     def test_excess_heat_factor_with_clip_true(self, ehi_sig, ehi_accl):
         exhf = tmf.excess_heat.excess_heat_factor(ehi_sig, ehi_accl, clip=True)
         np.testing.assert_allclose(exhf, [15.0, 5.0, 5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
-    def test_excess_heat_factor_with_clip_false(self, ehi_sig, ehi_accl):
+    def test_excess_cold_factor_with_clip_false(self, ehi_sig, ehi_accl):
         excf = tmf.excess_heat.excess_cold_factor(ehi_sig, ehi_accl, clip=False)
-        np.testing.assert_allclose(excf, [5.0, 5.0, 20.0, 0.0, 0.0, 0.0, -2.0, -2.0, -8.0])
+        np.testing.assert_allclose(
+            excf, [5.0, 5.0, 20.0, 0.0, 0.0, 0.0, -2.0, -2.0, -8.0]
+        )
 
-    def test_excess_heat_factor_with_clip_true(self, ehi_sig, ehi_accl):
+    def test_excess_cold_factor_with_clip_true(self, ehi_sig, ehi_accl):
         excf = tmf.excess_heat.excess_cold_factor(ehi_sig, ehi_accl, clip=True)
-        np.testing.assert_allclose(excf, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -2.0, -2.0, -8.0])
+        np.testing.assert_allclose(
+            excf, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -2.0, -2.0, -8.0]
+        )
 
 
 def test_heatwave_severity():

--- a/tests/test_excess_heat.py
+++ b/tests/test_excess_heat.py
@@ -19,11 +19,21 @@ def test_daily_mean_temperature():
     np.testing.assert_allclose(dmt, [3.0, 2.0, 4.0, 4.0, 6.0])
 
 
+def test_daily_mean_temperature_scalar():
+    dmt = tmf.excess_heat.daily_mean_temperature(1.0, 5.0)
+    assert dmt == pytest.approx(3.0)
+
+
 def test_significance_index():
     dmt = np.asarray([3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
     threshold = 5.0
     ehi_sig = tmf.excess_heat.significance_index(dmt, threshold)
     np.testing.assert_allclose(ehi_sig, [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0])
+
+
+def test_significance_index_scalar():
+    ehi_sig = tmf.excess_heat.significance_index(8.0, 5.0)
+    assert ehi_sig == pytest.approx(3.0)
 
 
 def test_acclimatisation_index():
@@ -33,8 +43,12 @@ def test_acclimatisation_index():
     np.testing.assert_allclose(ehi_accl, [1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 6.0])
 
 
-class TestExcessHeatAndColdFactors:
+def test_acclimatisation_index_scalar():
+    ehi_accl = tmf.excess_heat.acclimatisation_index(6.0, 3.0)
+    assert ehi_accl == pytest.approx(3.0)
 
+
+class TestExcessHeatAndColdFactors:
     @pytest.fixture
     def ehi_sig(self):
         return np.asarray([5.0, 5.0, 5.0, 0.0, 0.0, 0.0, -2.0, -2.0, -2.0])
@@ -53,6 +67,21 @@ class TestExcessHeatAndColdFactors:
         exhf = tmf.excess_heat.excess_heat_factor(ehi_sig, ehi_accl, clip=True)
         np.testing.assert_allclose(exhf, [15.0, 5.0, 5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
+    def test_excess_heat_factor_clip_false_positive_scalar(self):
+        assert tmf.excess_heat.excess_heat_factor(
+            5.0, 3.0, clip=False
+        ) == pytest.approx(15.0)
+
+    def test_excess_heat_factor_clip_false_negative_scalar(self):
+        assert tmf.excess_heat.excess_heat_factor(
+            -2.0, 3.0, clip=False
+        ) == pytest.approx(-6.0)
+
+    def test_excess_heat_factor_clip_true_negative_scalar(self):
+        assert tmf.excess_heat.excess_heat_factor(
+            -2.0, 3.0, clip=True
+        ) == pytest.approx(0.0)
+
     def test_excess_cold_factor_with_clip_false(self, ehi_sig, ehi_accl):
         excf = tmf.excess_heat.excess_cold_factor(ehi_sig, ehi_accl, clip=False)
         np.testing.assert_allclose(
@@ -65,6 +94,21 @@ class TestExcessHeatAndColdFactors:
             excf, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -2.0, -2.0, -8.0]
         )
 
+    def test_excess_cold_factor_clip_false_positive_scalar(self):
+        assert tmf.excess_heat.excess_cold_factor(
+            5.0, -4.0, clip=False
+        ) == pytest.approx(20.0)
+
+    def test_excess_cold_factor_clip_false_negative_scalar(self):
+        assert tmf.excess_heat.excess_cold_factor(
+            -2.0, -4.0, clip=False
+        ) == pytest.approx(-8.0)
+
+    def test_excess_cold_factor_clip_true_positive_scalar(self):
+        assert tmf.excess_heat.excess_cold_factor(
+            5.0, -4.0, clip=True
+        ) == pytest.approx(0.0)
+
 
 def test_heatwave_severity():
     exhf = np.asarray([[0.0, 1.0], [1.0, 2.0], [3.0, 1.0], [4.0, 0.0]])
@@ -72,3 +116,8 @@ def test_heatwave_severity():
     hsev = tmf.excess_heat.heatwave_severity(exhf, threshold=tr)
     ref = np.asarray([[0.0, 0.5], [0.4, 1.0], [1.2, 0.5], [1.6, 0.0]])
     np.testing.assert_allclose(hsev, ref)
+
+
+def test_heatwave_severity_scalar():
+    hsev = tmf.excess_heat.heatwave_severity(3.0, threshold=2.5)
+    assert hsev == pytest.approx(1.2)

--- a/tests/test_excess_heat.py
+++ b/tests/test_excess_heat.py
@@ -1,0 +1,68 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+import numpy as np
+import pytest
+
+import thermofeel as tmf
+
+
+def test_daily_mean_temperature():
+    t2_min = np.asarray([1., 2., 3., 4., 5.])
+    t2_max = np.asarray([5., 2., 5., 4., 7.])
+    dmt = tmf.excess_heat.daily_mean_temperature(t2_min, t2_max)
+    np.testing.assert_allclose(dmt, [3., 2., 4., 4., 6.])
+
+
+def test_significance_index():
+    dmt = np.asarray([3., 4., 5., 6., 7., 8., 9.])
+    threshold = 5.
+    ehi_sig = tmf.excess_heat.significance_index(dmt, threshold)
+    np.testing.assert_allclose(ehi_sig, [-2., -1., 0., 1., 2., 3., 4.])
+
+
+def test_acclimatisation_index():
+    dmt = np.asarray([3., 4., 5., 6., 7., 8., 9.])
+    threshold = np.asarray([2., 2., 3., 3., 4., 4., 3.])
+    ehi_accl = tmf.excess_heat.acclimatisation_index(dmt, threshold)
+    np.testing.assert_allclose(ehi_accl, [1., 2., 2., 3., 3., 4., 6.])
+
+
+class TestExcessHeatAndColdFactors:
+
+    @pytest.fixture
+    def ehi_sig(self):
+        return np.asarray([5.0, 5.0, 5.0, 0.0, 0.0, 0.0, -2.0, -2.0, -2.0])
+
+    @pytest.fixture
+    def ehi_accl(self):
+        return np.asarray([3.0, 0.0, -4.0, 3.0, 0.0, -4.0, 3.0, 0.0, -4.0])
+
+    def test_excess_heat_factor_with_clip_false(self, ehi_sig, ehi_accl):
+        exhf = tmf.excess_heat.excess_heat_factor(ehi_sig, ehi_accl, clip=False)
+        np.testing.assert_allclose(exhf, [15.0, 5.0, 5.0, 0.0, 0.0, 0.0, -6.0, -2.0, -2.0])
+
+    def test_excess_heat_factor_with_clip_true(self, ehi_sig, ehi_accl):
+        exhf = tmf.excess_heat.excess_heat_factor(ehi_sig, ehi_accl, clip=True)
+        np.testing.assert_allclose(exhf, [15.0, 5.0, 5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+    def test_excess_heat_factor_with_clip_false(self, ehi_sig, ehi_accl):
+        excf = tmf.excess_heat.excess_cold_factor(ehi_sig, ehi_accl, clip=False)
+        np.testing.assert_allclose(excf, [5.0, 5.0, 20.0, 0.0, 0.0, 0.0, -2.0, -2.0, -8.0])
+
+    def test_excess_heat_factor_with_clip_true(self, ehi_sig, ehi_accl):
+        excf = tmf.excess_heat.excess_cold_factor(ehi_sig, ehi_accl, clip=True)
+        np.testing.assert_allclose(excf, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -2.0, -2.0, -8.0])
+
+
+def test_heatwave_severity():
+    exhf = np.asarray([[0.0, 1.0], [1.0, 2.0], [3.0, 1.0], [4.0, 0.0]])
+    tr = np.asarray([2.5, 2.0])
+    hsev = tmf.excess_heat.heatwave_severity(exhf, threshold=tr)
+    ref = np.asarray([[0.0, 0.5], [0.4, 1.0], [1.2, 0.5], [1.6, 0.0]])
+    np.testing.assert_allclose(hsev, ref)

--- a/thermofeel/__init__.py
+++ b/thermofeel/__init__.py
@@ -6,7 +6,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from . import excess_heat  # noqa
 from .thermofeel import *  # noqa
-from . import excess_heat
 
 __version__ = "2.1.7"

--- a/thermofeel/__init__.py
+++ b/thermofeel/__init__.py
@@ -7,5 +7,6 @@
 # nor does it submit to any jurisdiction.
 
 from .thermofeel import *  # noqa
+from . import excess_heat
 
 __version__ = "2.1.7"

--- a/thermofeel/excess_heat.py
+++ b/thermofeel/excess_heat.py
@@ -11,12 +11,7 @@ import numpy as np
 
 def daily_mean_temperature(t2_min, t2_max):
     """
-    Daily mean temperature, computed from min and max only
-
-    The day is usually defined in the local timezone from 9 am to 9 am local
-    time, so that the daily maximum typically preceeds the daily minimum to
-    account for the greater significance of the human physiological response
-    to a hot night following a hot day compared to the other way around.
+    Daily mean temperature computed from min and max
 
         :param t2_min: 2-metre daily minimum temperature.
         :param t2_max: 2-metre daily maximum temperature.

--- a/thermofeel/excess_heat.py
+++ b/thermofeel/excess_heat.py
@@ -12,7 +12,7 @@ import numpy as np
 def daily_mean_temperature(t2_min, t2_max):
     """
     Daily mean temperature, computed from min and max only
-    
+
     The day is usually defined in the local timezone from 9 am to 9 am local
     time, so that the daily maximum typically preceeds the daily minimum to
     account for the greater significance of the human physiological response
@@ -20,7 +20,7 @@ def daily_mean_temperature(t2_min, t2_max):
 
         :param t2_min: 2-metre daily minimum temperature.
         :param t2_max: 2-metre daily maximum temperature.
-    
+
     Reference: Nairn and Fawcett (2014)
     https://doi.org/10.3390/ijerph120100227
     """

--- a/thermofeel/excess_heat.py
+++ b/thermofeel/excess_heat.py
@@ -1,0 +1,103 @@
+# (C) Copyright 2026- ECMWF and individual contributors.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+import numpy as np
+
+
+def daily_mean_temperature(t2_min, t2_max):
+    """
+    Daily mean temperature, computed from min and max only
+    
+    The day is usually defined in the local timezone from 9 am to 9 am local
+    time, so that the daily maximum typically preceeds the daily minimum to
+    account for the greater significance of the human physiological response
+    to a hot night following a hot day compared to the other way around.
+
+        :param t2_min: 2-metre daily minimum temperature.
+        :param t2_max: 2-metre daily maximum temperature.
+    
+    Reference: Nairn and Fawcett (2014)
+    https://doi.org/10.3390/ijerph120100227
+    """
+    return 0.5 * (t2_min + t2_max)
+
+
+def significance_index(dmt, threshold):
+    """
+    Significance index
+
+        :param dmt: 3-day running mean daily mean temperature (day i, i+1, i+2).
+        :param threshold: climatological threshold, e.g., 95th (heat extremes)
+            or 5th (cold extremes) percentile of daily mean temperature over a
+            reference period.
+
+    Reference: Nairn and Fawcett (2014), equation (1)
+    https://doi.org/10.3390/ijerph120100227
+    """
+    return dmt - threshold
+
+
+def acclimatisation_index(dmt, threshold):
+    """
+    Acclimatisation index
+
+        :param dmt: 3-day running mean daily mean temperature (days i, i+1, i+2).
+        :param: threshold: 30-day running mean daily mean temperature (days i-30, ..., i-1).
+
+    Reference: Nairn and Fawcett (2014), equation (2)
+    https://doi.org/10.3390/ijerph120100227
+    """
+    return dmt - threshold
+
+
+def excess_heat_factor(ehi_sig, ehi_accl, clip=False):
+    """
+    Excess heat factor
+
+        :param ehi_sig: Significance index, e.g., computed with respect to 95th
+            percentile of daily mean temperature over a reference period.
+        :param ehi_accl: Acclimatisation index.
+        :param clip: Whether to clip the lower value range at zero. Disabled by default.
+
+    Reference: Nairn and Fawcett (2014), equation (3)
+    https://doi.org/10.3390/ijerph120100227
+    """
+    if clip:
+        ehi_sig = np.maximum(0, ehi_sig)
+    return ehi_sig * np.maximum(1.0, ehi_accl)
+
+
+def heatwave_severity(exhf, threshold):
+    """
+    Heatwave severity index
+
+        :param exhf: Excess heat factor.
+        :param threshold: Excess heat factor threshold, the 85th percentile
+            of all positive excess heat factor values in a reference period.
+
+    Reference: Nairn (2018), equation (4)
+    https://doi.org/10.3390/ijerph15112494
+    """
+    return exhf / threshold
+
+
+def excess_cold_factor(ehi_sig, ehi_accl, clip=False):
+    """
+    Excess cold factor
+
+        :param ehi_sig: Significance index, e.g., computed with respect to 5th
+            percentile of daily mean temperature over a reference period..
+        :param ehi_accl: Acclimatisation index.
+        :param clip: Whether to clip the upper value range at zero. Disabled by default.
+
+    Reference: Nairn (2013), equation (7)
+    https://www.cawcr.gov.au/technical-reports/CTR_060.pdf
+    """
+    if clip:
+        ehi_sig = np.minimum(0, ehi_sig)
+    return -ehi_sig * np.minimum(-1.0, ehi_accl)

--- a/thermofeel/excess_heat.py
+++ b/thermofeel/excess_heat.py
@@ -42,7 +42,7 @@ def acclimatisation_index(dmt, threshold):
     Acclimatisation index
 
         :param dmt: 3-day running mean daily mean temperature (days i, i+1, i+2).
-        :param: threshold: 30-day running mean daily mean temperature (days i-30, ..., i-1).
+        :param threshold: 30-day running mean daily mean temperature (days i-30, ..., i-1).
 
     Reference: Nairn and Fawcett (2014), equation (2)
     https://doi.org/10.3390/ijerph120100227


### PR DESCRIPTION
### Description

The **Excess Heat Factor** (EXHF) and **Excess Cold Factor** (EXCF) are thermal indices that quantify the hazard of extreme heat and cold events.

Each index combines two components: a significance index that measures how much the current temperature exceeds a climatological threshold, and an acclimatisation index that measures how much the current temperature departs from the recent past. EXHF or EXCF indicate events that are both unusually hot or cold relative to climatology and to which the population has had little time to acclimatise, and are therefore associated with elevated health risk.

**Main reference**: Nairn, J., & Fawcett, R. (2014). https://doi.org/10.3390/ijerph120100227

### Notes on the implementation

Transfer of formulas from https://github.com/ecmwf/earthkit-meteo/pull/89.

The implemented computations are very basic since the complexity is mainly in the temporal aggregations. These are left for earthkit-transforms (note included in the documentation).

The value of the added functions lies in the associated documentation and domain-specific naming.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 