### PR TITLE
Add opencode agent commands and fix index-list doc drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ?.*
 !.gitignore
 !.github
+!.opencode
 __pycache__/
 htmlcov
 .coverage

--- a/.opencode/command/address-pr-comments.md
+++ b/.opencode/command/address-pr-comments.md
@@ -1,0 +1,88 @@
+---
+description: Address all unresolved review comments on a GitHub PR and push fixes
+agent: build
+---
+
+# Address Pull Request Comments
+
+Review and resolve all feedback on a GitHub pull request.
+
+## Arguments
+
+Provide the PR number as argument, e.g. `/address-pr-comments 32`
+If no number given, detect the current branch's open PR.
+
+## Process
+
+### 1. Fetch Reviews
+First, fetch all comments in **unresolved** threads and reviews:
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "ecmwf", name: "thermofeel") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 50) {
+        nodes {
+          isResolved
+          comments(first: 1) {
+            nodes { path line originalLine body }
+          }
+        }
+      }
+    }
+  }
+}' | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | "File: \(.comments.nodes[0].path)\nLine: \(.comments.nodes[0].line // .comments.nodes[0].originalLine)\nComment: \(.comments.nodes[0].body)\n---"'
+```
+This provides the actual inline review comments which `gh pr view` doesn't show properly, and filters out resolved threads.
+
+Also obtain reviews and root-level comments with
+```
+gh api repos/{owner}/{repo}/pulls/<NUMBER>/comments
+gh api repos/{owner}/{repo}/pulls/<NUMBER>/reviews
+```
+
+### 2. Analyze Each Comment
+
+For each review comment or inline comment:
+- Read the full context of the code being discussed
+- Understand the reviewer's concern in light of this project's philosophy:
+  - **Scientific correctness first** — every formula matches its cited
+    reference; validate against published worked examples, not a self-generated
+    number
+  - **The SI-unit in/out contract** (Kelvin, m/s, %, hPa) is upheld at the
+    public boundary (see `plans/DESIGN.md`)
+  - **This is a published library** — public signatures in
+    `thermofeel/thermofeel.py` and the `helpers.py` converters are a contract;
+    behaviour changes follow SemVer and are recorded in `CHANGELOG.md`
+  - Proper fixes over workarounds; no suppressed lints/tests
+- If the intent is ambiguous, ask the user for clarification before acting
+
+### 3. Address Issues
+
+For each actionable comment:
+- Fix the code as requested (or propose a better alternative with justification)
+- Update documentation (`docs/`, docstrings) if the change affects public API or
+  behaviour, and `CHANGELOG.md` for any user-facing change
+- Add or update tests if the comment identified a gap (scalar and/or array
+  suite, plus `tests/test_robustness.py` for edge/`NaN` behaviour)
+
+### 4. Push and Verify
+
+- Commit changes with a clear message referencing the review feedback
+- Push to update the PR
+- Wait for CI to finish:
+  ```bash
+  gh pr checks <NUMBER> --watch
+  ```
+- If CI fails, fix and push again
+
+### 5. Iterate
+
+Continue the loop until:
+- All review comments have been addressed
+- CI is green
+- Summarize what was changed in response to each comment
+
+### 6. Report
+
+Provide a summary mapping each reviewer comment to the action taken.

--- a/.opencode/command/copilot-review-loop.md
+++ b/.opencode/command/copilot-review-loop.md
@@ -1,0 +1,38 @@
+---
+description: Run the Copilot review loop on a PR until it converges
+agent: build
+---
+
+# Copilot review loop
+
+You are running the Copilot review loop on PR **$ARGUMENTS**. The loop is the contract; one round is not enough. Resolve `<owner>`, `<repo>`, and `<pr>` from `$ARGUMENTS` (accept a number, a PR URL, or `owner/repo#N`; default to the current repo via `gh repo view --json nameWithOwner` if only a number is given).
+
+## Requesting a review
+
+The only request form that works is the literal-bot-suffix form of the REST API:
+
+```bash
+gh api --method POST \
+  /repos/<owner>/<repo>/pulls/<pr>/requested_reviewers \
+  -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+```
+
+`copilot-pull-request-reviewer` (without the `[bot]` suffix) returns `422 Reviews may only be requested from collaborators`. `Copilot` returns 200 but silently drops the request. The `requestReviews` GraphQL mutation returns `NOT_FOUND` for the bot's node id. None of those work. The literal `[bot]` suffix on the reviewer name is the only path; the successful response shows `requested_reviewers: [{login: "Copilot", type: "Bot"}]` and the bot posts a review within a few minutes.
+
+## The loop
+
+1. **Request a review** using the command above.
+2. **Watch for the review.** Poll BOTH endpoints in tandem: `gh api repos/<owner>/<repo>/pulls/<pr>/reviews` for the review count, and `gh api repos/<owner>/<repo>/pulls/<pr>/requested_reviewers` for the bot's state. After the request, `requested_reviewers` shows `[{login: "Copilot", type: "Bot"}]` (the bot has the request queued); it clears back to `[]` when the bot finishes processing. Two outcomes from there:
+   - **A new review IS posted** (`reviews` count rises): continue to step 3.
+   - **`requested_reviewers` cleared and no new review was posted**: the bot processed the request and had nothing to add. Stop the loop now. **Do not run a confirmation pass**; the cleared `requested_reviewers` is itself the terminating signal.
+
+   Five minutes is a reasonable cap for the bot to process a request. If `requested_reviewers` has not cleared after that, request again.
+3. **Read every comment in the new review.** For each thread, either fix or reject:
+   - **Fix** if the finding is correct. Keep commits focused — one concern per commit; restructures, renames, and reorganisations split into their own commits.
+   - **Reject** if the finding is a false positive, a misreading of the code, a misinterpretation of a deliberate decision (e.g. the documented SI-unit contract, an intentional `NaN`/`Inf` domain edge, a cited formula), or otherwise does not warrant a change. Do NOT silently apply suggestions that would degrade the code, contradict documented design, or revert deliberate work. A rejected finding gets a reply that names the reason in one sentence.
+4. **Reply to each comment** with `gh api repos/<owner>/<repo>/pulls/<pr>/comments -f body=... -F in_reply_to=<comment_database_id>` and **resolve each thread** via the GraphQL `resolveReviewThread` mutation against the thread node id.
+5. **Push the fix commits** before requesting the next round so Copilot reviews the new state, not the stale one.
+6. **Request another review** and repeat from step 2.
+7. **Stop the loop** when one of these holds: Copilot processed a request without posting a new review (`requested_reviewers` cycled `[Copilot] → []` and the reviews count did not rise); or the latest posted review surfaces no new actionable findings (review body says "no issues", or every comment is a duplicate of one already resolved, or every comment is a false positive already rejected with reasoning). The loop terminates on Copilot's behaviour, not on a fixed count, and a single round meeting either condition is enough; no confirmation pass.
+
+Begin now with step 1 for PR $ARGUMENTS.

--- a/.opencode/command/doc-fact-check.md
+++ b/.opencode/command/doc-fact-check.md
@@ -1,0 +1,105 @@
+---
+description: Run docs code examples and verify prose claims against the codebase
+agent: build
+---
+
+# Documentation Fact-Check
+
+Run code examples in the docs and verify prose claims against the actual codebase.
+
+## Arguments
+
+`$ARGUMENTS` — optional file paths relative to `docs/` to narrow the scope.
+
+If no arguments given, check all `.md` files under `docs/`. Accepts individual
+files (`guide/utci.md`) or directories (`guide/`).
+
+Examples: `/doc-fact-check guide/utci.md`, `/doc-fact-check guide/`, `/doc-fact-check`
+
+## Setup
+
+```bash
+make venv                                   # uv-managed .venv with the package + test deps
+.venv/bin/python -c "import thermofeel; print('OK')"
+```
+
+If any setup step fails, report it and continue with what works. Blocks that
+fail due to environment issues (missing tool, unbuilt dependency) are **not**
+doc bugs — report them separately as setup problems.
+
+Note: `docs/api.md` is generated from the source docstrings by **mkdocstrings**,
+so signatures there cannot drift from the code — but the hand-written prose and
+examples in `docs/index.md`, `docs/examples.md`, and `docs/guide/*.md` can.
+
+## 1. Run Code Examples
+
+For each fenced code block in the selected docs:
+
+### Classify each block
+- **Runnable** — self-contained Python: has its own imports, no `...` ellipsis
+  placeholders, does not need user-specific data files
+- **Continuation** — follows a runnable block on the same page and reuses its
+  variables; concatenate with its predecessor
+- **Skip** — partial snippets, signatures-only, output samples (lines starting
+  with `>>>` output or `$`), unlabeled code blocks (no language tag),
+  install/setup commands (`pip install`, `make ...`), or blocks needing
+  user-specific files (GRIB/NetCDF inputs, `*.grib`, `*.nc`)
+
+### Execute runnable blocks
+
+**Python:** write to a temp `.py` file, run `.venv/bin/python <file>`. 30s
+timeout per block. Most examples import `numpy` and `thermofeel` and pass NumPy
+arrays — remember several functions require array (not scalar) input.
+
+**Bash:** only commands that can run without user-specific data. Run and check
+exit code 0.
+
+**Never** invent missing imports or variables. If a block isn't self-contained, skip it.
+
+Record pass/fail/skip for every block.
+
+## 2. Check Claims Against Code
+
+Read each doc file and find verifiable factual claims — these are inline code
+spans (`` `calculate_utci` ``), numbers, units, citations, and table cells, not
+prose paragraphs. For each one, check the source.
+
+**What to check:**
+- **API names / signatures** — function names, parameter names, defaults
+  mentioned in prose → verify they exist and match in `thermofeel/thermofeel.py`,
+  `thermofeel/helpers.py`, `thermofeel/excess_heat.py` (e.g. `threshold=0.1`,
+  `wind_scaling="liljegren"`, `clip=False`)
+- **Units** — every documented input/output unit must match the SI contract the
+  function actually implements (Kelvin, m/s at 10 m, %, hPa); flag any place a
+  guide states the wrong unit
+- **Scientific citations** — author/year and DOI/URL in a guide page must match
+  the reference in the corresponding function docstring
+- **Validity ranges** — documented windows (e.g. Wind Chill −50…+5 °C and
+  5…80 km/h, the Heat-Index 20 °C gate, UTCI polynomial ranges) must match the
+  docstring and the code's branch conditions
+- **The index list** — the computed-indices list must agree across `README.md`,
+  the `thermofeel/thermofeel.py` module docstring, and `docs/guide/overview.md`
+  (the "keep in step" rule in AGENTS.md)
+- **Numerical claims** — any worked-example value quoted in the docs → recompute
+  it and confirm
+
+**What NOT to check:** subjective claims ("accurate", "physically based"),
+high-level explanatory prose that makes no testable assertion.
+
+## 3. Report
+
+For each finding:
+```
+[ERROR|STALE|DRIFT] file.md:LINE — Summary
+  Docs say: <what the docs claim>
+  Code says: <what the source actually shows>
+```
+
+- **ERROR** — code example fails, API doesn't exist, wrong signature/unit
+- **STALE** — outdated value, renamed API, removed function, wrong citation
+- **DRIFT** — minor mismatch (index list out of step, slightly different default)
+
+End with a summary: total files checked, blocks run/passed/failed/skipped,
+number of claim issues found.
+
+For ERROR findings: propose a fix but do **not** apply it — present for user review.

--- a/.opencode/command/improve-code-coverage.md
+++ b/.opencode/command/improve-code-coverage.md
@@ -1,0 +1,75 @@
+---
+description: Measure coverage and fill gaps until the package is at >=95%
+agent: build
+---
+
+# Improve Code Coverage
+
+Perform a comprehensive code coverage analysis and fill gaps to reach 95%+ coverage.
+
+## Process
+
+### 1. Measure Current Coverage
+
+```bash
+make test       # runs pytest with --cov=thermofeel --cov-report=term-missing
+```
+
+Or directly, to iterate on one area:
+```bash
+.venv/bin/python -m pytest tests/ --cov=thermofeel --cov-report=term-missing
+```
+
+Coverage config lives in `pyproject.toml` (`[tool.coverage]`, branch coverage
+on); CI uploads to Codecov (`codecov.yml`).
+
+### 2. Identify Gaps
+
+For each module below 95% coverage (`thermofeel/thermofeel.py`,
+`thermofeel/liljegren.py`, `thermofeel/excess_heat.py`, `thermofeel/helpers.py`):
+- Read the source to understand which code paths and branches are untested
+- Categorize each gap as:
+  - **(a) Needs new tests** — testable code paths with no coverage
+  - **(b) Domain/edge path** — a `NaN`/`Inf` or out-of-domain branch (the
+    closed-form `bgt` calm-air limit, Liljegren non-convergence, a `ValueError`
+    contract); test it via `tests/test_robustness.py`
+  - **(c) Dead code** — unreachable code that should be removed
+
+### 3. Prioritize by Impact
+
+Focus on the modules with the largest absolute gaps first — typically the
+index functions in `thermofeel.py` and the Liljegren solvers in `liljegren.py`.
+
+### 4. Write Tests
+
+- Add tests to the EXISTING suites, matching their patterns and style:
+  - `tests/test_thermofeel.py` — array-level regression against the stored
+    `tests/*.csv` reference outputs
+  - `tests/test_scalars.py` — pointwise checks against individually verified
+    reference values (this is where edge-case reasoning lives)
+  - `tests/test_robustness.py` — `NaN`/`Inf` propagation and error contracts
+  - `tests/test_excess_heat.py` — the excess-heat submodule
+- Each test should target a specific uncovered code path or branch
+- Test error paths and domain edges, not just the happy path
+- Validate any new expected value against the literature / a worked example and
+  record its provenance in the test — never just pin whatever the code emits
+
+### 5. Remove Dead Code
+
+If coverage analysis reveals unreachable code:
+- Verify it's truly unreachable (not just untested)
+- **Remove it** rather than adding `# pragma: no cover`. Per AGENTS.md,
+  suppression to dodge coverage is prohibited; the only accepted pragma is on the
+  `unittest.main()` entrypoints.
+
+### 6. Verify
+
+- Run `make all` to confirm all tests pass and lint is clean
+- Re-measure coverage to confirm improvement
+- Report before/after comparison by module
+
+## Target
+
+Aim for at least **95% line + branch coverage** across `thermofeel/` (the suite
+has historically reached 100%). Acceptable exceptions are limited to the
+`if __name__ == "__main__": unittest.main()` entrypoints.

--- a/.opencode/command/improve-edge-cases.md
+++ b/.opencode/command/improve-edge-cases.md
@@ -1,0 +1,59 @@
+---
+description: Systematic numerical edge-case audit and patching across the library
+agent: build
+---
+
+# Improve Edge Case Handling
+
+Perform a systematic edge-case audit across the library. thermofeel is a pure
+numerical library, so the risk surface is numerical: does each formula return a
+correct, finite, well-defined value across the range of inputs it can be handed,
+and does it behave predictably at the edges? Use `plans/ROBUSTNESS.md` (findings
+R-1…R-8) and `tests/test_robustness.py` as the baseline — extend them, don't
+duplicate them.
+
+## What to Look For
+
+### Input-value edge cases
+- Empty arrays, single-element arrays, 0-D scalars wrapped in arrays, very large
+  arrays
+- `NaN`, `+Inf`, `-Inf`, negative zero, subnormals — confirm they propagate
+  elementwise to `NaN`/`Inf` rather than raising
+- Boundary humidity (`rh = 0` → `np.log` domain), boundary/zero/negative wind
+  (the `calculate_bgt` closed-form root; the calm-air `bgt -> mrt` limit),
+  `cossza → 0` (the `approximate_dsrp` threshold guard and the Liljegren
+  `cza_safe` / `tan(sza)` guards)
+- Integer-typed input arrays — must not silently truncate a float result (see
+  R-7); preserve dtype with `dtype=float` where results are fractional
+
+### Domain / validity-range cases
+- Each index that is only defined over a range (Wind Chill −50…+5 °C and
+  5…80 km/h; the Heat-Index 20 °C gate and the adjusted Heat-Index cold / low-
+  humidity / high-humidity branches; UTCI polynomial ranges; Stull wet-bulb
+  RH 5…99 %). Inputs are **not** clamped — confirm the documented behaviour
+  (out-of-range in → out-of-range out) and that it is stated in the docstring
+- The `calculate_utci` `ValueError` when neither `ehPa` nor `td_k` is supplied
+- Liljegren non-convergence returning `NaN` (the C reference's −9999 sentinel)
+  and `calculate_heat_force` propagating that `NaN` rather than a spurious band
+
+### Calling-convention cases
+- Functions that branch internally with `np.where` / boolean indexing
+  (`calculate_heat_index_simplified`, `approximate_dsrp`,
+  `calculate_saturation_vapour_pressure_multiphase`) require array input —
+  confirm the array contract is documented and behaves consistently
+
+## Process
+
+1. Scan each module and identify unhandled or under-tested edge cases
+2. For ambiguous behaviour, ask the user to clarify the intended semantics
+   (mask vs. propagate vs. raise) before changing anything — do NOT add a guard
+   that masks genuine out-of-domain input
+3. Add handling only where a guard is clearly correct (e.g. the analytic calm-air
+   limit), preserving the "validity ranges are documented, not clamped" rule
+4. Write tests for each edge case in `tests/test_robustness.py` (and the scalar
+   suite where a specific value matters)
+5. Document the behaviour: update the function docstring, `docs/`, and the
+   `plans/ROBUSTNESS.md` findings log (ID, severity, surface, status, the
+   regression test that pins it)
+6. Run `make all` to verify no regressions
+7. Summarize findings and changes (grouped, with the ROBUSTNESS.md IDs)

--- a/.opencode/command/improve-error-handling.md
+++ b/.opencode/command/improve-error-handling.md
@@ -1,0 +1,56 @@
+---
+description: Audit the error / NaN-Inf contracts across the library and tighten them up
+agent: build
+---
+
+# Improve Error Handling
+
+Perform an error-handling audit across the library. thermofeel runs inside
+trusted pipelines on trusted NumPy arrays; it does not parse byte streams, use
+FFI, or touch the network/filesystem in its core. The "error model" is therefore
+about two things: the few explicit `ValueError` contracts, and the defined
+`NaN`/`Inf` behaviour at domain edges. See `plans/ROBUSTNESS.md` §3 for the
+invariants.
+
+## Checks
+
+### Exception contracts
+- `ValueError` is raised where it is the correct contract, with a clear,
+  actionable message — e.g. `calculate_utci` given neither `ehPa` nor `td_k`;
+  `calculate_wbgt_liljegren` given an unknown `wind_scaling`. Confirm each is
+  tested in `tests/test_robustness.py`
+- Functions do NOT raise on finite, correctly-shaped array input — domain edge
+  cases yield `NaN`/`Inf` per NumPy semantics, not exceptions
+- No bare `except:` and no overly broad exception swallowing anywhere in
+  `thermofeel/`
+
+### NaN / Inf as a defined contract
+- A `NaN` input yields a `NaN` output elementwise (never a spurious finite
+  value, never a raise); converging neighbours in an array are unaffected
+- Where an input drives a formula out of its mathematical domain (`rh = 0` →
+  `log`; non-convergent Liljegren iteration; the zero-wind `bgt` indeterminate),
+  the resulting `NaN`/`Inf` is the **documented, tested** outcome — not incidental
+- Guards that exist to avoid spurious warnings (`np.errstate`, `cza_safe`, the
+  `approximate_dsrp` threshold) must not mask genuinely bad input (e.g. negative
+  wind still yields `NaN`)
+
+### Documentation
+- Each public function's docstring states its units, validity range, and any
+  `NaN`/`Inf` / `ValueError` behaviour
+- `plans/ROBUSTNESS.md` records each finding (ID, severity, surface, status,
+  mitigation, regression test); update it when behaviour changes
+- `docs/` describes the calling convention (array input; not clamped) so callers
+  know masking out-of-range points is their responsibility
+
+## Process
+
+1. Scan all of `thermofeel/` for raise sites, bare excepts, and error-swallowing
+   patterns; and for `log`/`sqrt`/`power`/division domains that can go `NaN`/`Inf`
+2. For each finding: classify (wrong/missing exception, undocumented `NaN`/`Inf`,
+   poor message, masks real bad input)
+3. Fix each issue — raise the right error with a clear message, or document and
+   test the `NaN`/`Inf` outcome; never add a guard that hides genuine
+   out-of-domain input
+4. Run `make all` to verify no regressions
+5. Update `plans/ROBUSTNESS.md` and the affected docstrings/`docs/`
+6. Summarize all changes made

--- a/.opencode/command/make-further-pass.md
+++ b/.opencode/command/make-further-pass.md
@@ -1,0 +1,99 @@
+---
+description: "Run a strictness-graded quality review pass — usage: /make-further-pass <pass-number>"
+agent: build
+---
+
+# Further Pass Review
+
+Perform a quality review pass over the codebase or the specified area.
+
+**This is pass number $ARGUMENTS (default: 2 if not specified).**
+
+Track the pass number and increase strictness with each successive pass.
+thermofeel is a small, **published**, pure-Python (numpy-only) numerical
+library; reviews focus on scientific correctness, the SI-unit contract,
+numerical robustness, and keeping the duplicated sources of truth in step — not
+on systems-level concerns.
+
+## Pass 1-2 (Foundation)
+- Simplification opportunities — reduce complexity, remove redundancy
+- Naming quality — variables, functions, parameters, modules
+- Comments and docstring quality — accurate, helpful, not redundant; each
+  public function still names its scientific reference (author, year + DOI/URL)
+- Identify duplicate sources of truth introduced or touched by this change
+  (the same value or generated content kept in two places without a guard)
+- Running the required formatter/lint/tests (`make fmt`, then `make all`)
+
+## Pass 3-4 (Hardening)
+Everything from Pass 1-2, PLUS:
+- Scan for edge-cases and logical regressions (see `/improve-edge-cases`)
+- Vectorisation: no Python-level loops over array elements; conditional logic
+  uses `np.where` / boolean indexing, never per-element `if`
+- SI-unit boundary: any formula that converts to °C/°F/km-h internally converts
+  back so the public boundary stays SI (Kelvin, m/s, %, hPa); the documented
+  exception (excess heat/cold factors) is intentional
+- All documentation up-to-date with changes (`docs/`, docstrings, `README.md`)
+- `NaN`/`Inf` behaviour at domain edges is documented and intentional, not
+  incidental (cross-check `plans/ROBUSTNESS.md`)
+- Public API surface is minimal and clean; no dead code, no unused imports, no
+  stale TODOs
+- NO suppression smell: no `# noqa`, `# type: ignore`, `# fmt: off`,
+  `@pytest.mark.skip`, or `# pragma: no cover` added to dodge a real problem
+  (the existing `unittest.main()` pragma is the one accepted case)
+
+- Duplicate source-of-truth drift scan. Each hit must be inspected; the greps
+  are not auto-fail rules — most matches are legitimate, but every match is a
+  candidate for a value that has drifted from its canonical source.
+
+  ```bash
+  # The package version lives ONLY in thermofeel/__init__.py (__version__);
+  # pyproject.toml reads it dynamically. Any other literal version is suspect.
+  git grep -nE '[0-9]+\.[0-9]+\.[0-9]+' -- pyproject.toml thermofeel/ \
+    | grep -viE 'python_requires|requires-python|target-version|py3[0-9]|>=|CY[0-9]'
+  make version            # must match thermofeel/__init__.py
+  make check              # imports the package and resolves the version
+
+  # The list of computed indices must stay in step across these three places:
+  git grep -nE 'Excess Heat|Wind Chill|Heat Force|Liljegren|Universal Thermal' \
+    -- README.md thermofeel/thermofeel.py docs/guide/overview.md
+  ```
+
+  For the index list: `README.md`, the `thermofeel/thermofeel.py` module
+  docstring, and `docs/guide/overview.md` must agree (AGENTS.md "Derived
+  artefacts have one source of truth"). For the version: only
+  `thermofeel/__init__.py` carries it.
+
+- Reference-data freshness. The committed `tests/*.csv` are the regression
+  baseline. If this change moved any of them, confirm it is a deliberate formula
+  correction (regenerate via the test's commented `np.savetxt(...)` line, record
+  it in `CHANGELOG.md` with the scientific justification and citation) — never a
+  silently re-baselined bug. Never weaken a `decimal=` tolerance to pass.
+
+## Pass 5+ (Polish)
+Everything from Pass 3-4, PLUS with ZERO TOLERANCE:
+- Every public function has a complete docstring with units and a citation
+- Every error path and `ValueError` contract is tested
+- Every documented edge case has a test (scalar AND array suites where it makes
+  sense — `tests/test_scalars.py`, `tests/test_thermofeel.py`,
+  `tests/test_robustness.py`)
+- Code reads like well-written prose — a newcomer could follow each formula back
+  to its reference
+- Performance: no unnecessary array copies or temporaries on the global-grid
+  hot paths; dtype is preserved (no silent integer truncation)
+- Consistency: similar patterns handled the same way everywhere (wind scaling
+  via `scale_windspeed`, unit conversion via `helpers.py`)
+- Fresh-environment check for tooling/packaging changes. If this change touches
+  `pyproject.toml`, the `Makefile`, `requirements.txt`, or the wheel contents,
+  rebuild from a clean env (`make clean && make venv && make all`, and
+  `make build` to inspect `dist/`) — packaging regressions only show up on a
+  fresh build.
+
+## Process
+
+1. State which pass number this is and what strictness level applies
+2. Scan the codebase (or specified files/area)
+3. List all findings grouped by category
+4. Fix each finding, verifying the fix passes tests
+5. Run the formatter and linter: `make fmt` then `make lint`
+6. Run the full gate: `make all` (and `make docs` if docs changed)
+7. Summarize what was changed and what the next pass should focus on

--- a/.opencode/command/make-release.md
+++ b/.opencode/command/make-release.md
@@ -1,0 +1,98 @@
+---
+description: "Cut a new release — usage: /make-release <X.Y.Z>"
+agent: build
+---
+
+# Make Release
+
+Create a new release of thermofeel (a pure-Python package published to PyPI).
+
+## Arguments
+
+Provide the version as the first argument, e.g. `/make-release 2.3.0`.
+If no version is given, default to a MINOR bump of the current
+`thermofeel/__init__.py` `__version__`.
+
+> **Canonical tooling:** `make release` drives `scripts/release.py`; the version
+> contract is in `AGENTS.md` "Version control". This command automates that
+> procedure — keep the two in sync.
+
+`__version__` in `thermofeel/__init__.py` is the **single source of truth**;
+`pyproject.toml` reads it dynamically. Tags are **bare** `MAJOR.MINOR.MICRO`
+(NO leading `v`). thermofeel is a **published** library — follow SemVer: MINOR
+for new features, MICRO for fixes/docs, and **NEVER bump MAJOR unless the user
+explicitly says so**.
+
+## Pre-release Checks
+
+Run these in order. If ANY step fails, STOP and prompt the user.
+
+### 1. Clean, pushed working tree
+```bash
+git status                      # must be clean — all changes committed
+git fetch origin
+git rev-parse HEAD origin/main  # HEAD must equal origin/main (pushed, in sync)
+```
+`scripts/release.py` blocks unless you are on `main`, the tree is clean, and
+`HEAD` matches `origin/main` — releases are cut from a pushed `main`.
+
+### 2. CHANGELOG entry (curated by hand)
+The `## X.Y.Z` section must already exist in `CHANGELOG.md` before releasing —
+it is never auto-generated. Add it by hand, matching the existing format (a
+`## X.Y.Z` heading followed by flat bullets; this repo does NOT use
+`[Unreleased]` or Keep-a-Changelog Added/Changed/Fixed sections). Summarise the
+user-facing changes since the last tag (`git log <last-tag>..HEAD --oneline`),
+and for any formula change cite the reference and rationale.
+
+### 3. Build and inspect the artefacts
+```bash
+make build      # builds sdist + wheel into dist/ and runs `twine check`
+```
+Confirm the wheel ships only the `thermofeel` package (no `tests/`, `examples/`,
+`scripts/`).
+
+### 4. Full gate
+```bash
+make all        # check + test + lint (the local gate)
+```
+`make release ... CONFIRM=1` re-runs `make all` itself before tagging (unless
+`SKIP_GATE=1`), but run it yourself first so failures surface early.
+
+## Release Process
+
+### 1. Plan the release (no changes made)
+```bash
+make release X.Y.Z
+```
+This validates everything (SemVer relation, tag not already present, CHANGELOG
+section, clean+synced `main`) and prints the plan — it makes NO changes.
+
+### 2. Apply: bump, commit, tag
+```bash
+make release X.Y.Z CONFIRM=1
+```
+With `CONFIRM=1` the tooling runs the gate, bumps `__version__` forward to
+`X.Y.Z` if needed (NEVER backward), commits `Release X.Y.Z`, and creates the
+annotated bare tag. It **NEVER pushes** — it prints the exact `git push`
+commands. (A MAJOR bump additionally requires `ALLOW_MAJOR=1`, which you only set
+when the user has explicitly approved a MAJOR release.)
+
+### 3. Publish (push the tag)
+Pushing the tag triggers `.github/workflows/cd.yml`, which builds and publishes
+to PyPI. **Only push with explicit user approval.**
+```bash
+git push origin main        # if the version-bump commit was made
+git push origin X.Y.Z       # pushing the bare tag triggers the cd workflow -> PyPI
+```
+
+### 4. Verify on PyPI
+Wait for the `cd` workflow to finish and for PyPI to propagate (~1-2 min), then
+smoke-test in a throwaway environment:
+```bash
+pip install thermofeel==X.Y.Z
+python -c "import thermofeel; print(thermofeel.__version__)"
+```
+
+**IMPORTANT:** Version tags are bare semver (e.g. `2.3.0`), NEVER prefixed with `v`.
+**IMPORTANT:** NEVER bump MAJOR unless the user explicitly says so.
+**IMPORTANT:** NEVER push to remote without explicit user approval.

--- a/.opencode/command/onboard.md
+++ b/.opencode/command/onboard.md
@@ -1,0 +1,99 @@
+---
+description: Onboard the agent to the thermofeel project by reading the docs and surveying the code
+agent: plan
+---
+
+# Onboard to the Project
+
+Build a working mental model of this repository so you can act competently
+on it. Do NOT rely on any knowledge baked into this command — derive
+everything from the repository's own files as they exist right now.
+
+## Arguments
+
+`$ARGUMENTS` — optional focus area (e.g. `utci`, `wbgt`, `liljegren`,
+`excess-heat`, `robustness`, `docs`). If given, go deeper on that area during
+the code survey (Step 3) while still doing the full doc pass. If empty, do a
+balanced survey across the whole library.
+
+## 1. Read the project-level docs
+
+Read these first, in order. They are the source of truth for *intent*:
+
+- The root markdown files: `README.md`, `AGENTS.md` (canonical agent
+  instructions; `CLAUDE.md` is a symlink to it), `CONTRIBUTING.md`,
+  `CHANGELOG.md` (read the most recent release section(s) for current
+  direction — the changelog is hand-curated `## X.Y.Z` flat bullets, NOT
+  Keep-a-Changelog and with no `[Unreleased]` section). Also skim
+  `ACKNOWLEDGEMENTS.md`.
+- Every `plans/*.md` file. Read each one fully. They cover motivation, the
+  design rationale + SI-unit contract, the architecture / data-flow between
+  indices, the test plan, the numerical-robustness analysis, the accepted-work
+  backlog, and speculative ideas.
+
+If a root markdown file or a `plans/*.md` file exists that is not named above,
+read it too — discover them with a glob rather than assuming a fixed list.
+Treat `plans/IDEAS.md` as speculative/unreviewed (it says so itself), not as
+committed direction.
+
+## 2. Map the repository structure
+
+Without reading every file, establish the layout:
+
+- The Python package `thermofeel/` and its modules (`thermofeel.py` — the
+  public API; `liljegren.py` — internal WBGT solvers; `excess_heat.py`;
+  `helpers.py` — SI unit converters; `__init__.py` — the public surface and the
+  canonical `__version__`).
+- Where tests, examples, docs, and release tooling live (`tests/`, `examples/`,
+  `docs/`, `scripts/`).
+- The build/test entry point: start from the `Makefile` — run nothing, just
+  read the target graph (`make help`). Note that the package depends only on
+  `numpy` at runtime and is managed with `uv`.
+
+## 3. Survey the code (representative, not exhaustive)
+
+Read enough source to understand *how the project achieves its purpose* — the
+public surface and the core data flow — NOT every file. Aim for:
+
+- The public `calculate_*` API in `thermofeel/thermofeel.py` and the SI-unit
+  input/output contract every function honours (Kelvin, m/s at 10 m, %, hPa).
+- How indices are composed from supporting quantities — follow a couple of the
+  dependency chains in `plans/ARCHITECTURE.md` end to end (e.g.
+  `saturation_vapour_pressure` → UTCI; `bgt` → `wbgt`; `mrt` → UTCI).
+- The three WBGT implementations and how `calculate_wbgt_liljegren` delegates to
+  the internal `thermofeel/liljegren.py` energy-balance solvers and 2 m wind
+  profile.
+- The unit-converter boundary in `thermofeel/helpers.py` and how each empirical
+  formula converts in/out so the public boundary stays SI.
+- The error / NaN-Inf model and the numerical invariants the code enforces
+  (cross-check what `plans/ROBUSTNESS.md` claims against what the code does).
+
+Prefer LSP / symbol navigation where available; fall back to Grep/Read.
+When the docs and the code disagree, trust the code and note the drift.
+
+## 4. Report back
+
+Produce a concise onboarding summary (do not change any files):
+
+1. **Purpose** — what the library is and the problem it solves, in 2-3 lines.
+2. **Architecture** — the package modules and how they relate (a short list or
+   a small diagram).
+3. **Core data flow** — one index traced end to end, from SI inputs through any
+   supporting quantities to the SI result.
+4. **Conventions that constrain edits** — the non-negotiable rules an agent must
+   respect here (pulled from `AGENTS.md` / `plans/DESIGN.md`): the SI in/out
+   contract, the version single-source-of-truth (`thermofeel/__init__.py`),
+   SemVer for a *published* library (never bump MAJOR unbidden), every formula
+   cited, vectorised over NumPy (no Python loops), no suppressed lints/tests,
+   the `make all` gate, the commit/PR workflow.
+5. **How to build, test, and lint** — the canonical commands (the gate to run
+   before marking work done): `make all`.
+6. **Current direction & open work** — what's active vs. speculative, from the
+   latest `CHANGELOG.md` section and `plans/TODO.md` (accepted) vs.
+   `plans/IDEAS.md` (speculative).
+7. **Anything stale or contradictory** you noticed between docs and code (e.g.
+   the index list must stay in step across `README.md`, the
+   `thermofeel/thermofeel.py` module docstring, and `docs/`).
+
+Keep it tight and skimmable. The goal is a shared mental model, not a copy of
+the docs.

--- a/.opencode/command/prepare-make-pr.md
+++ b/.opencode/command/prepare-make-pr.md
@@ -1,0 +1,51 @@
+---
+description: Run pre-flight checks then commit, push and open the PR
+agent: build
+---
+
+# Prepare and Create Pull Request
+
+Final preparation check and PR creation workflow.
+
+## Pre-flight Checks
+
+Run the full gate. If it fails, STOP and report the failure — do not open the PR.
+
+```bash
+make all          # check + test + lint (pure Python: import-check, pytest, ruff)
+```
+
+`make all` is the single source of truth for the pre-commit gate; it wraps the
+underlying `pytest` and `ruff` commands (run `make help` for the individual
+targets). Do NOT run a narrower subset in its place. Run `make fmt` first to
+auto-apply lint fixes and formatting.
+
+If the change touches `docs/` or any docstring, also build the docs:
+
+```bash
+make docs         # mkdocs build --strict
+```
+
+## PR Creation
+
+If all checks pass:
+
+1. Review what files to include — stage only source, test, doc, and config files.
+2. Do NOT stage: `.venv/`, `dist/`, `build/`, `site/`, `*.egg-info/`,
+   `__pycache__/`, `.coverage`, `coverage.xml`, or any local data
+   (`*.grib`, `*.npz`). `.github/` and `.opencode/` ARE tracked.
+3. If not already on a feature branch, create one off `main` using the
+   convention `<type>/<kebab-summary>` (`feat`, `fix`, `docs`, `chore`,
+   `refactor`, `test`, `ci`, `perf`, `build`).
+4. Commit with a clear message matching the repo style.
+5. Record every user-facing change in `CHANGELOG.md` under the current
+   release section before opening the PR.
+6. Push to origin.
+7. Create a pull request against `ecmwf/thermofeel` `main` with:
+   - Title: concise summary of the change
+   - Body: what changed and why; for any formula change, the reference and
+     rationale; how it was verified (tests/examples)
+   - Link to any related issues
+8. Report the PR URL.
+
+Only commit, push, or open a PR when the user has asked you to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,46 @@ Useful focused targets (run `make help` for the complete list):
   raw tool commands so there is one source of truth — see the *Building* and
   *Testing* sections of `CONTRIBUTING.md`.
 
+# Development workflow
+
+The lifecycle below maps each phase to a bundled slash-command in
+`.opencode/command/` (opencode discovers them automatically as `/<name>`).
+Humans follow the same phases, just without the `/`-commands.
+
+1. **Onboard** — `/onboard` reads the docs and surveys the code to build a
+   mental model of the library.
+2. **Pick work** — take an item from `plans/TODO.md` (the accepted backlog).
+   `plans/IDEAS.md` is speculative and is NOT committed direction.
+3. **Plan** — before writing code, say how you will verify it, plan the TDD
+   tests (this repo has both array-regression and pointwise-scalar suites — add
+   to both where it makes sense, plus `tests/test_robustness.py` for edge /
+   `NaN` behaviour), take a behaviour-driven approach, ask clarifying questions,
+   and summarise the design + implementation plan (see *Guidelines* above).
+4. **Branch** — branch off `main` using `<type>/<kebab-summary>`, where
+   `<type>` is one of `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`,
+   `perf`, `build`.
+5. **Develop** — follow the conventions here and in `plans/DESIGN.md` (the SI
+   in/out contract; every formula cited; vectorised over NumPy). Document new
+   features under `docs/` and add a runnable `examples/` script for any new
+   public API. Record every user-facing change in `CHANGELOG.md` under the
+   current release section as you go.
+6. **Quality passes** — `/make-further-pass` (strictness-graded), plus, as
+   needed, `/improve-code-coverage`, `/improve-edge-cases`,
+   `/improve-error-handling`, and `/doc-fact-check`. (There is no mutation-
+   testing gate in this repo.)
+7. **Gate** — `make all` must be green (the single pre-commit gate; see
+   *Build / lint / test* above).
+8. **Open the PR** — `/prepare-make-pr` runs `make all`, then commits on the
+   feature branch, pushes, and opens the PR. Only commit / push / open a PR when
+   the user has asked you to.
+9. **Review loop** — `/copilot-review-loop` drives the Copilot reviewer to
+   convergence; `/address-pr-comments` resolves human review threads and waits
+   on CI (`gh pr checks --watch`).
+10. **Release** — `/make-release`; full contract in *Version control* below.
+
+`main` is the single integration branch; agents NEVER push, merge, or open a PR
+without explicit user approval.
+
 # Version control
 
 - Git project at github.com/ecmwf/thermofeel; single `main` branch.

--- a/thermofeel/thermofeel.py
+++ b/thermofeel/thermofeel.py
@@ -20,6 +20,7 @@ thermofeel is a library to calculate human thermal comfort indexes.
   * Wet Bulb Globe Temperature Simple
   * Wet Bulb Globe Temperature (Liljegren method)
   * Heat Force (KNMI 0-10 heat-stress scale)
+  * Excess Heat Factor and Excess Cold Factor
   * Wind Chill
 
   In support of the above indexes, it also calculates:


### PR DESCRIPTION
## What

Adds a set of bundled **opencode slash-commands** under `.opencode/command/`, adapted from the tensogram repo's `.prompts/` to thermofeel's pure-Python, published-library conventions, and fixes a small documentation drift.

## Commands added (`.opencode/command/`)

`onboard`, `make-further-pass`, `make-release`, `prepare-make-pr`, `address-pr-comments`, `copilot-review-loop`, `doc-fact-check`, `improve-code-coverage`, `improve-edge-cases`, `improve-error-handling`.

Each was rewritten (not copied) for the language/process differences:

- Toolchain mapped to **uv / ruff / pytest / MkDocs** and the repo's `make` targets.
- `make-release` matched to `scripts/release.py` — single PyPI package, bare `MAJOR.MINOR.MICRO` tags, SemVer, never push without approval.
- `improve-edge-cases` / `improve-error-handling` / `make-further-pass` re-aimed from Rust panics / FFI / codegen-drift to thermofeel's **numerical** risk surface, the SI-unit contract, and `plans/ROBUSTNESS.md`.

## Wire-up & consistency

- **`.gitignore`**: un-ignore `.opencode` so the commands are tracked despite the leading `.*` dotfile-ignore rule.
- **`AGENTS.md`**: new *Development workflow* section mapping each lifecycle phase to its `/command`, plus the `<type>/<kebab-summary>` branch convention (also visible via the `CLAUDE.md` symlink).

## Documentation drift fix

- **`thermofeel/thermofeel.py`**: add `Excess Heat Factor and Excess Cold Factor` to the module-docstring index list so it matches `README.md` and `docs/guide/overview.md` (the keep-in-step rule in `AGENTS.md`).

## Verification

- `make all` → 86 passed, **100% coverage**, ruff lint + format clean.
- `make docs` (strict) → builds clean.
- All `make` targets and file paths referenced by the commands exist; no leftover tensogram/Rust references.

No library code behaviour changes (docstring-only edit to `thermofeel.py`).