### PR TITLE
Avoid unnecessary PMV and Liljegren iteration for NaN rows

### DIFF
--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -18,6 +18,8 @@ import numpy as np
 import pytest
 
 import thermofeel as tmf
+from thermofeel import liljegren
+from thermofeel import thermofeel as thermofeel_module
 from thermofeel.helpers import fahrenheit_to_celsius
 
 # Representative finite inputs (Kelvin / m s-1 / % / hPa).
@@ -28,6 +30,15 @@ VA = np.array([3.0])
 MRT = np.array([310.0])
 Q = np.array([100.0])  # body-absorbed net radiation [W m-2]
 NAN = np.array([np.nan])
+
+
+def _solve_globe(inputs):
+    return liljegren.solve_globe(*inputs)
+
+
+def _solve_wetbulb(inputs):
+    return liljegren.solve_wetbulb(*inputs, 1.0)
+
 
 # Each entry maps a NaN temperature through one public index.
 NAN_CASES = {
@@ -81,6 +92,56 @@ def test_wbgt_liljegren_nan_element_propagates():
     assert np.isnan(out[1])
 
 
+@pytest.mark.parametrize(
+    ("solver", "convection", "expected"),
+    [
+        (_solve_globe, "h_sphere_in_air", 35.96840506),
+        (_solve_wetbulb, "h_cylinder_in_air", 19.95920111),
+    ],
+)
+def test_liljegren_solvers_skip_nan_rows_without_extra_iterations(
+    monkeypatch, solver, convection, expected
+):
+    finite_inputs = (
+        np.array([298.15]),
+        np.array([0.5]),
+        np.array([1013.0]),
+        np.array([2.0]),
+        np.array([500.0]),
+        np.array([0.5]),
+        np.array([0.5]),
+    )
+    original_convection = getattr(liljegren, convection)
+    calls = 0
+
+    def count_iterations(*args):
+        nonlocal calls
+        calls += 1
+        return original_convection(*args)
+
+    monkeypatch.setattr(liljegren, convection, count_iterations)
+
+    finite = solver(finite_inputs)
+    finite_calls = calls
+    np.testing.assert_allclose(finite, [expected], rtol=1e-8)
+
+    calls = 0
+    mixed_inputs = tuple(
+        np.array([values[0], np.nan if index == 0 else values[0]])
+        for index, values in enumerate(finite_inputs)
+    )
+    mixed = solver(mixed_inputs)
+    assert calls == finite_calls
+    np.testing.assert_allclose(mixed[0], finite[0])
+    assert np.isnan(mixed[1])
+
+    calls = 0
+    all_invalid_inputs = (np.array([np.nan]), *finite_inputs[1:])
+    all_invalid = solver(all_invalid_inputs)
+    assert calls == 0
+    assert np.isnan(all_invalid).all()
+
+
 def test_ppd_nan_propagates():
     # calculate_ppd is a pure map of PMV; a NaN vote (e.g. a non-converged PMV
     # element) propagates to NaN rather than raising or returning a spurious %.
@@ -100,17 +161,47 @@ def test_relative_strain_index_singularity_and_sign_flip():
     assert rsi[1] < 0.0  # 36 degC / 100% RH: e ~ 59 hPa > 58 -> spurious negative
 
 
-def test_pmv_nonconvergence_returns_nan():
-    # A NaN element never satisfies the convergence test, so the vectorised fixed
-    # point runs to its iteration cap and returns NaN for it (the documented
-    # non-convergence behaviour), while a finite neighbour still converges.
-    t2 = tmf.celsius_to_kelvin(np.array([22.0, np.nan]))
-    tr = tmf.celsius_to_kelvin(np.array([22.0, 22.0]))
-    var = np.array([0.1, 0.1])
-    rh = np.array([60.0, 60.0])
-    pmv = tmf.calculate_pmv(t2, tr, var, rh=rh)
-    assert np.isfinite(pmv[0])
-    assert np.isnan(pmv[1])
+def test_pmv_skips_nan_rows_without_extra_iterations(monkeypatch):
+    finite_inputs = (
+        tmf.celsius_to_kelvin(np.array([22.0])),
+        tmf.celsius_to_kelvin(np.array([22.0])),
+        np.array([0.1]),
+        np.array([60.0]),
+    )
+    original_maximum = thermofeel_module.np.maximum
+    calls = 0
+
+    def count_iterations(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_maximum(*args, **kwargs)
+
+    monkeypatch.setattr(thermofeel_module.np, "maximum", count_iterations)
+
+    finite = tmf.calculate_pmv(*finite_inputs[:3], rh=finite_inputs[3])
+    finite_calls = calls
+    np.testing.assert_allclose(finite, [-0.75256792], rtol=1e-8)
+
+    calls = 0
+    mixed = tmf.calculate_pmv(
+        tmf.celsius_to_kelvin(np.array([22.0, np.nan])),
+        tmf.celsius_to_kelvin(np.array([22.0, 22.0])),
+        np.array([0.1, 0.1]),
+        rh=np.array([60.0, 60.0]),
+    )
+    assert calls == finite_calls
+    np.testing.assert_allclose(mixed[0], finite[0])
+    assert np.isnan(mixed[1])
+
+    calls = 0
+    all_invalid = tmf.calculate_pmv(
+        tmf.celsius_to_kelvin(np.array([np.nan])),
+        finite_inputs[1],
+        finite_inputs[2],
+        rh=finite_inputs[3],
+    )
+    assert calls == 0
+    assert np.isnan(all_invalid).all()
 
 
 def test_bgt_zero_wind_returns_mrt():

--- a/thermofeel/liljegren.py
+++ b/thermofeel/liljegren.py
@@ -71,6 +71,12 @@ LSRDT = np.array(
 URBAN_EXP = np.array([0.15, 0.15, 0.20, 0.25, 0.30, 0.30])
 
 
+def _finite_mask(*values: ArrayLike) -> np.ndarray:
+    return np.logical_and.reduce(
+        np.broadcast_arrays(*(np.isfinite(value) for value in values))
+    )
+
+
 def esat(tk: ArrayLike) -> np.ndarray:
     """Saturation vapour pressure over liquid water [hPa], Buck (1981)."""
     y = (tk - 273.15) / (tk - 32.18)
@@ -166,7 +172,9 @@ def solve_globe(
 
     tg_prev = np.array(ta, dtype=float, copy=True)
     result = np.full(np.shape(ta), np.nan, dtype=float)
-    converged = np.zeros(np.shape(ta), dtype=bool)
+    pending = _finite_mask(ta, rh, pair, speed, solar, fdir, cza)
+    if not pending.any():
+        return result
     for _ in range(MAX_ITER):
         tref = 0.5 * (tg_prev + ta)
         h = h_sphere_in_air(tref, pair, speed)
@@ -178,11 +186,11 @@ def solve_globe(
             * (1.0 - ALB_GLOBE)
             * (beam + 1.0 + ALB_SFC)
         ) ** 0.25
-        now = (~converged) & (np.abs(tg_new - tg_prev) < CONVERGENCE)
+        now = pending & (np.abs(tg_new - tg_prev) < CONVERGENCE)
         result = np.where(now, tg_new - 273.15, result)
-        converged = converged | now
-        tg_prev = np.where(converged, tg_prev, 0.9 * tg_prev + 0.1 * tg_new)
-        if converged.all():
+        pending &= ~now
+        tg_prev = np.where(pending, 0.9 * tg_prev + 0.1 * tg_new, tg_prev)
+        if not pending.any():
             break
     return result
 
@@ -213,7 +221,9 @@ def solve_wetbulb(
 
     tw_prev = dew_point(eair)
     result = np.full(np.shape(ta), np.nan, dtype=float)
-    converged = np.zeros(np.shape(ta), dtype=bool)
+    pending = _finite_mask(ta, rh, pair, speed, solar, fdir, cza, rad)
+    if not pending.any():
+        return result
     for _ in range(MAX_ITER):
         tref = 0.5 * (tw_prev + ta)
         h = h_cylinder_in_air(tref, pair, speed)
@@ -232,11 +242,11 @@ def solve_wetbulb(
             - evap(tref) / RATIO * (ewick - eair) / (pair - ewick) * (PR / sc) ** 0.56
             + (fatm / h) * rad
         )
-        now = (~converged) & (np.abs(tw_new - tw_prev) < CONVERGENCE)
+        now = pending & (np.abs(tw_new - tw_prev) < CONVERGENCE)
         result = np.where(now, tw_new - 273.15, result)
-        converged = converged | now
-        tw_prev = np.where(converged, tw_prev, 0.9 * tw_prev + 0.1 * tw_new)
-        if converged.all():
+        pending &= ~now
+        tw_prev = np.where(pending, 0.9 * tw_prev + 0.1 * tw_new, tw_prev)
+        if not pending.any():
             break
     return result
 

--- a/thermofeel/thermofeel.py
+++ b/thermofeel/thermofeel.py
@@ -1275,9 +1275,9 @@ def calculate_pmv(
 
     Fanger's steady-state heat-balance comfort equation as standardised in
     ISO 7730:2005. The clothing-surface temperature is obtained by the Annex D
-    fixed-point iteration (tolerance 0.00015, capped at 150 sweeps). The whole
-    array is iterated together (mirroring the Liljegren energy-balance solvers)
-    and any element that has not converged within the cap is returned as NaN.
+    fixed-point iteration (tolerance 0.00015, capped at 150 sweeps). Finite
+    rows are iterated together and any element that has not converged within
+    the cap is returned as NaN.
 
     ``met`` and ``clo`` are exposed as parameters because PMV is only defined for
     a stated activity and clothing level; the defaults (1.2 met, 0.5 clo) are
@@ -1341,18 +1341,27 @@ def calculate_pmv(
     xf = xn
     hc = np.zeros(bshape, dtype=float)
     converged = np.zeros(bshape, dtype=bool)
+    pending = (
+        np.isfinite(xn)
+        & np.isfinite(hcf)
+        & np.isfinite(p2)
+        & np.isfinite(p3)
+        & np.isfinite(p4)
+        & np.isfinite(p5)
+    )
     for _ in range(150):
+        if not pending.any():
+            break
         xf_new = (xf + xn) / 2.0
         hcn = 2.38 * np.abs(100.0 * xf_new - taa) ** 0.25
         hc_new = np.maximum(hcf, hcn)
         xn_new = (p5 + p4 * hc_new - p2 * xf_new**4) / (100.0 + p3 * hc_new)
-        update = ~converged
-        xf = np.where(update, xf_new, xf)
-        xn = np.where(update, xn_new, xn)
-        hc = np.where(update, hc_new, hc)
-        converged = converged | (np.abs(xn_new - xf_new) <= eps)
-        if converged.all():
-            break
+        xf = np.where(pending, xf_new, xf)
+        xn = np.where(pending, xn_new, xn)
+        hc = np.where(pending, hc_new, hc)
+        now = pending & (np.abs(xn_new - xf_new) <= eps)
+        converged |= now
+        pending &= ~now
 
     tcl = 100.0 * xn - 273.0  # clothing-surface temperature [degC]
 


### PR DESCRIPTION
## Summary

- exclude non-finite rows from Liljegren and PMV convergence masks;
- retain `NaN` outputs for invalid rows;
- stop iteration once all eligible rows converge;
- add deterministic mixed-row iteration regressions.

## Verification

- `make test`
- `make docs`
- `git diff --check`

## CI note

The QA job currently fails because it installs an unpinned Ruff version. See separeate PR [#57](https://github.com/ecmwf/thermofeel/pull/57)