### PR TITLE
Pin Ruff for reproducible QA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install ruff
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install ruff==0.15.0
       - name: Ruff lint (config in pyproject.toml)
         run: ruff check thermofeel tests scripts
       - name: Ruff format check

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ PYTHON  ?= $(VENV)/bin/python
 # ruff (linter + formatter) runs in an ephemeral uv environment (`--no-project`
 # so uv does not build thermofeel just to run a linter). Config lives in
 # pyproject.toml under [tool.ruff].
-RUFF    ?= $(UV) run --no-project --with ruff ruff
+RUFF    ?= $(UV) run --no-project --with ruff==0.15.0 ruff
 
 # Code that the QA tools operate on (the package, its tests, helper scripts,
 # and the validation campaign).


### PR DESCRIPTION
## Summary

- pin Ruff to `0.15.0` in GitHub Actions;
- use the same Ruff version for the local `make lint` gate.

## Verification

- `make all`
- `make docs`
- `git diff --check`